### PR TITLE
chore: bump agn version to 0.5.1

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli v0.14.9 adds message-id tracing correlation.
 AGYND_VERSION=0.14.9
 AGYN_VERSION=0.2.7
-AGN_VERSION=0.5.0
+AGN_VERSION=0.5.1


### PR DESCRIPTION
## Summary
- bump AGN_VERSION to 0.5.1 for embedded token counting

## Testing
- bash -c 'rg -n "^AGYND_VERSION=" versions.env && rg -n "^AGYN_VERSION=" versions.env && rg -n "^AGN_VERSION=" versions.env'

## Issue
- #43