### PR TITLE
Bump agynd version to 0.14.12

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
-# agynd-cli v0.14.9 adds message-id tracing correlation.
-AGYND_VERSION=0.14.9
+# agynd-cli v0.14.12 adds message-id tracing correlation.
+AGYND_VERSION=0.14.12
 AGYN_VERSION=0.2.7
 AGN_VERSION=0.5.1

--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
-# agynd-cli v0.14.12 adds message-id tracing correlation.
+# agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
 AGYND_VERSION=0.14.12
 AGYN_VERSION=0.2.7
 AGN_VERSION=0.5.1


### PR DESCRIPTION
## Summary
- bump AGYND_VERSION to 0.14.12

## Testing
- bash -c 'set -a; source versions.env; docker build --build-arg AGYND_VERSION=$AGYND_VERSION --build-arg AGYN_VERSION=$AGYN_VERSION --build-arg AGN_VERSION=$AGN_VERSION --build-arg TARGETARCH=amd64 -t agent-init-agn:local .'

Closes #48