### PR TITLE
chore(versions): bump agyn-cli to 0.2.8

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
 AGYND_VERSION=0.14.12
-AGYN_VERSION=0.2.7
+AGYN_VERSION=0.2.8
 AGN_VERSION=0.5.1


### PR DESCRIPTION
## Summary
- bump AGYN_VERSION to 0.2.8 for agyn-cli release v0.2.8

## Testing
- not run (versions.env change only)

## Issue
#29