### PR TITLE
chore(versions): bump agyn-cli to 0.2.9

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.12
-AGYN_VERSION=0.2.8
+AGYND_VERSION=0.14.13
+AGYN_VERSION=0.2.9
 AGN_VERSION=0.5.1


### PR DESCRIPTION
## Summary
- bump embedded agyn CLI to 0.2.9
- bump embedded agynd CLI to 0.14.13 so rebuilt init images include the self-subscribe notification fix

## Context
`agyn-cli` v0.2.9 and `agynd-cli` v0.14.13 are released and include the notification self-subscribe changes needed for agent `--wait` flows.

## Validation
- version pins updated in `versions.env`