### PR TITLE
chore: bump agynd to 0.14.14

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.13
+AGYND_VERSION=0.14.14
 AGYN_VERSION=0.2.9
 AGN_VERSION=0.5.1


### PR DESCRIPTION
Bumps AGYND_VERSION to 0.14.14 to pick up the agynd PATH fix that adds /agyn-bin to agent subprocess PATH.\n\nMerge after agynio/agynd-cli v0.14.14 release artifacts are published.