### PR TITLE
chore(versions): bump agyn-cli to 0.2.10

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
 AGYND_VERSION=0.14.14
-AGYN_VERSION=0.2.9
+AGYN_VERSION=0.2.10
 AGN_VERSION=0.5.1


### PR DESCRIPTION
Bumps agyn-cli used in the image build to 0.2.10 (via versions.env).