### PR TITLE
chore(versions): bump agynd to 0.14.15

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.14
+AGYND_VERSION=0.14.15
 AGYN_VERSION=0.2.10
 AGN_VERSION=0.5.1


### PR DESCRIPTION
Bump AGYND_VERSION to 0.14.15 to pick up improved operation-specific timeout/cancel logging.