### PR TITLE
fix(init): update agyn cli expose output

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
 AGYND_VERSION=0.14.15
-AGYN_VERSION=0.2.10
+AGYN_VERSION=0.2.11
 AGN_VERSION=0.5.1


### PR DESCRIPTION
## Summary

- Bump bundled `agyn-cli` to v0.2.11 so `agyn expose add/list --output json` includes OpenZiti resource IDs.
- Fixes agynio/agent-init-agn#56.
- Supports agynio/agents-orchestrator#207 E2E tracking.

## Validation

- `git diff --check`

Docker build was attempted locally, but the sandbox Docker daemon hung while fetching Alpine package indexes. The release workflow builds the image from this one-line version bump after merge/tag.

## Test & Lint Summary

- Tests: not applicable; this repo only changes `versions.env` and has no test workflow for PRs.
- Lint/static checks: `git diff --check` passed with no whitespace errors.