### PR TITLE
chore: bump agynd to v0.14.27

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.15
+AGYND_VERSION=0.14.27
 AGYN_VERSION=0.2.11
 AGN_VERSION=0.5.1


### PR DESCRIPTION
## Summary

- Bump `AGYND_VERSION` to `0.14.27` so the AGN init image includes the terminal Codex turn failure fix from agynd-cli PR #147.

Closes #58

## Validation

- Version-only change to `versions.env`.
- Release workflow will build and verify multi-arch image after tag `v0.5.7` is created post-merge.