### PR TITLE
chore: bump agynd to v0.14.28

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.27
+AGYND_VERSION=0.14.28
 AGYN_VERSION=0.2.11
 AGN_VERSION=0.5.1


### PR DESCRIPTION
Closes #60

## Summary
- Bump `AGYND_VERSION` from `0.14.27` to `0.14.28` in `versions.env`.
- Prepare this init image for the next expected release tag `v0.5.8` so AO can consume the MCP readiness fix from agynd-cli v0.14.28.

## Validation
- `env -i sh -c 'set -a; . ./versions.env; test \"$AGYND_VERSION\" = \"0.14.28\"; test -n \"${AGYN_VERSION:-}\"'`: passed.
- `curl -fsI https://github.com/agynio/agynd-cli/releases/download/v0.14.28/agynd-linux-amd64`: passed.
- `curl -fsI https://github.com/agynio/agynd-cli/releases/download/v0.14.28/agynd-linux-arm64`: passed.
- `git diff --check`: passed with no whitespace errors.
- `docker build --platform linux/arm64 --build-arg TARGETARCH=arm64 ... -t local/agent-init-agn:agynd-0.14.28 .`: 1 image built / 0 failed.
- `docker run --rm --platform linux/arm64 -v <volume>:/agyn-bin local/agent-init-agn:agynd-0.14.28`: passed.
- `docker run --rm --platform linux/arm64 -v <volume>:/agyn-bin alpine:3.21 sh -c '<binary checks>'`: passed.