### PR TITLE
fix: bump agynd to 0.14.29

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.28
+AGYND_VERSION=0.14.29
 AGYN_VERSION=0.2.11
 AGN_VERSION=0.5.1


### PR DESCRIPTION
## Summary
- Bump `AGYND_VERSION` from `0.14.28` to `0.14.29` in `versions.env`.
- No release tag created.

Closes #62

## Test & Lint Summary
- `sh -eu -c '. ./versions.env; test "$AGYND_VERSION" = "0.14.29"; grep -qx "AGYND_VERSION=0.14.29" versions.env; count=$(grep -c "^AGYND_VERSION=" versions.env); test "$count" -eq 1'` — passed.
- `docker build --build-arg AGYND_VERSION="$AGYND_VERSION" --build-arg AGYN_VERSION="$AGYN_VERSION" --build-arg AGN_VERSION="$AGN_VERSION" --build-arg TARGETARCH=arm64 -t agent-init-agn:agynd-0.14.29 .` — passed.
- `docker run` container copy smoke check plus Alpine validation of `/agyn-bin/agynd`, `/agyn-bin/cli/agyn`, and `/agyn-bin/config.json` — passed.
- Tests: 3 passed, 0 failed, 0 skipped.
- Linting/version validation passed with no errors.
