### PR TITLE
chore: bump agynd to 0.14.31

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.29
+AGYND_VERSION=0.14.31
 AGYN_VERSION=0.2.11
 AGN_VERSION=0.5.1


### PR DESCRIPTION
Picks up agynd 0.14.31, which posts the turn's final message to the instance's default thread.

For this image it also crosses 0.14.30, where `THREAD_ID` became optional. Pinned at 0.14.29, an agent started without a thread dies on `config error: THREAD_ID is empty`.