### PR TITLE
chore: bump agynd to 0.14.32

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.31
+AGYND_VERSION=0.14.32
 AGYN_VERSION=0.2.11
 AGN_VERSION=0.5.1


### PR DESCRIPTION
Codex agents hung at startup with no logs. The codex in this image cannot build an `otlp-grpc` exporter, so it exited before answering `initialize`, and agynd waited on that handshake with no deadline. 0.14.32 exports over OTLP/HTTP and deadlines the handshake.