### PR TITLE
chore: bump the agyn CLI to 0.2.19

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
 AGYND_VERSION=0.14.32
-AGYN_VERSION=0.2.11
+AGYN_VERSION=0.2.19
 AGN_VERSION=0.5.1


### PR DESCRIPTION
The `agyn` CLI baked into this image was still on 0.2.10/0.2.11 while the CLI is at 0.2.19 — it predates the `agents` command group and the threads/messages alignment, so an agent could not use them. agynd is already on 0.14.32.