### PR TITLE
chore: bump agynd to 0.14.33

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.32
+AGYND_VERSION=0.14.33
 AGYN_VERSION=0.2.19
 AGN_VERSION=0.5.1


### PR DESCRIPTION
Inbox items now reach the agent with a source header: thread or direct, sender handle, then `---` before the body.