### PR TITLE
chore: bump agn to 0.5.2

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
 AGYND_VERSION=0.14.33
 AGYN_VERSION=0.2.19
-AGN_VERSION=0.5.1
+AGN_VERSION=0.5.2


### PR DESCRIPTION
An empty follow-up LLM call no longer fails the turn, so agynd stops retrying a message whose tool calls already ran and posting the reply twice.