### PR TITLE
chore: bump agn to 0.5.3

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
 AGYND_VERSION=0.14.33
 AGYN_VERSION=0.2.19
-AGN_VERSION=0.5.2
+AGN_VERSION=0.5.3


### PR DESCRIPTION
A turn whose work was tool calls no longer fails at save, so agynd stops replaying the message and posting the reply repeatedly.