### PR TITLE
chore: bump agn to 0.5.4

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
 AGYND_VERSION=0.14.33
 AGYN_VERSION=0.2.19
-AGN_VERSION=0.5.3
+AGN_VERSION=0.5.4


### PR DESCRIPTION
A turn that answers with tool calls no longer reports failure, so agynd stops replaying the message.