### PR TITLE
feat: carry only the agn CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: ghcr.io/agynio/agent-init-agn
+  IMAGE_NAME: ghcr.io/agynio/agyn-runtime-agn
 
 jobs:
   image:
@@ -41,9 +41,7 @@ jobs:
         id: versions
         run: |
           set -a
-          source versions.env
-          echo "AGYND_VERSION=$AGYND_VERSION" >> "$GITHUB_OUTPUT"
-          echo "AGYN_VERSION=$AGYN_VERSION" >> "$GITHUB_OUTPUT"
+          source VERSION
           echo "AGN_VERSION=$AGN_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Extract Docker metadata
@@ -66,13 +64,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            AGYND_VERSION=${{ steps.versions.outputs.AGYND_VERSION }}
-            AGYN_VERSION=${{ steps.versions.outputs.AGYN_VERSION }}
             AGN_VERSION=${{ steps.versions.outputs.AGN_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=agent-init-agn
-          cache-to: type=gha,scope=agent-init-agn,mode=max
+          cache-from: type=gha,scope=agyn-runtime-agn
+          cache-to: type=gha,scope=agyn-runtime-agn,mode=max
 
       - name: Verify multi-arch manifest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,15 @@
 # syntax=docker/dockerfile:1
 FROM alpine:3.21
 
-ARG AGYND_VERSION
-ARG AGYN_VERSION
 ARG AGN_VERSION
 ARG TARGETARCH
 
-RUN mkdir -p /tools/cli
+# agynd and the agyn CLI are not here: they ship with the platform and arrive
+# in the same volume from their own init images, so this pins one agent CLI.
+RUN mkdir -p /tools
 
 RUN apk add --no-cache curl && \
-    curl -fsSL "https://github.com/agynio/agynd-cli/releases/download/v${AGYND_VERSION}/agynd-linux-${TARGETARCH}" \
-      -o /tools/agynd && \
-    chmod +x /tools/agynd && \
-    curl -fsSL "https://github.com/agynio/agyn-cli/releases/download/v${AGYN_VERSION}/agyn-linux-${TARGETARCH}" \
-      -o /tools/cli/agyn && \
-    chmod +x /tools/cli/agyn
-
-RUN curl -fsSL "https://github.com/agynio/agn-cli/releases/download/v${AGN_VERSION}/agn-linux-${TARGETARCH}" \
+    curl -fsSL "https://github.com/agynio/agn-cli/releases/download/v${AGN_VERSION}/agn-linux-${TARGETARCH}" \
       -o /tools/agn && \
     chmod +x /tools/agn
 

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,3 @@
+# The only version this repository pins. agynd and the agyn CLI are no longer
+# among its contents, so bumping one agent CLI rebuilds nothing else.
+AGN_VERSION=0.5.5

--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,0 @@
-# agynd-cli >=0.14.10 fixes Notifications Subscribe rooms (issue #48).
-AGYND_VERSION=0.14.34
-AGYN_VERSION=0.2.19
-AGN_VERSION=0.5.5


### PR DESCRIPTION
Per [Environment and Runtime Unification](https://github.com/agynio/architecture/blob/main/changes/2026-08-03-environment-runtime-unification.md). Same change as agynio/agyn-runtime-codex#72 and agynio/agyn-runtime-claude#60.