### PR TITLE
State the CLI relative to the volume

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
   "sdk": "agn",
-  "bin": "/agyn/bin/agn"
+  "bin": "bin/agn"
 }


### PR DESCRIPTION
An absolute `bin` asserts where the platform mounted the volume; the image only knows what it carries. agynd resolves it against the mount and now rejects an absolute value.