### PR TITLE
Take agn 0.5.6

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # The only version this repository pins. agynd and the agyn CLI are no longer
 # among its contents, so bumping one agent CLI rebuilds nothing else.
-AGN_VERSION=0.5.5
+AGN_VERSION=0.5.6


### PR DESCRIPTION
agn writes into the trace `agynd` opened rather than rooting one of its own, so the turns it reports land in the wake cycle that asked for them.

It reads `TRACEPARENT`, which agynd 0.23.4 hands it — agynio/agn-cli#69 and agynio/agynd-cli#196. Until both are in a workload, an agn agent's `llm.call` and `tool.execution` spans sit in a trace of their own, and the platform's run view shows the message and the model call it caused as unrelated things that happened near each other.