### PR TITLE
Take agn 0.5.7

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # The only version this repository pins. agynd and the agyn CLI are no longer
 # among its contents, so bumping one agent CLI rebuilds nothing else.
-AGN_VERSION=0.5.6
+AGN_VERSION=0.5.7


### PR DESCRIPTION
agn no longer records `invocation.message` when its caller already has — agynio/agn-cli#70.

Under the platform `agynd` opens the trace and records that span before the message reaches agn, so agn recording a second one put two on a single turn and a reader counting turns saw two. It became visible once agn started writing into agynd's trace rather than one of its own.